### PR TITLE
feat(ghp): add fresh and cleanup commands

### DIFF
--- a/skills/ghp/SKILL.md
+++ b/skills/ghp/SKILL.md
@@ -8,11 +8,13 @@ description: Guide for GitHub project management via `gh` CLI — issues, PRs, m
 This skill provides the development workflow reference. Use these commands for specific actions:
 
 - `/ghp:init` — Start a session: read project state, summarize, and pick what to work on
+- `/ghp:fresh` — Bootstrap a fresh agent onto an issue (or pick from Todo)
 - `/ghp:new-milestone` — Create a milestone with issues, branches, and project tracking in one flow
 - `/ghp:work` — See in-progress issues and pick the best one to continue
 - `/ghp:wrap-issue` — Close out an issue: summarize, PR to milestone branch, close sub-issues
 - `/ghp:wrap-milestone` — Close out a milestone: summarize, PR to main, close issues
 - `/ghp:organize` — Triage unorganized issues into the Project board
+- `/ghp:cleanup` — Clean up stale branches, dead milestones, and orphaned issues
 - `/ghp:create-template` — Scaffold a Project with standard board layout and mark as template
 
 ## Extensions required

--- a/skills/ghp/commands/cleanup/SKILL.md
+++ b/skills/ghp/commands/cleanup/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: ghp:cleanup
+description: Clean up stale branches, closed issue remnants, and dead milestones. Scans for branches with no open issue, closed milestones with lingering branches, and issues referencing deleted code. Always asks before deleting.
+allowed-tools:
+  - Bash(gh issue *)
+  - Bash(gh milestone *)
+  - Bash(gh issue-ext *)
+  - Bash(gh pm *)
+  - Bash(git *)
+---
+
+# /ghp:cleanup — Clean Up Stale Artifacts
+
+Scans for stale branches, dead milestones, and orphaned issues. Always asks the user before taking action.
+
+## Flow
+
+1. **Scan remote branches:**
+   ```bash
+   git fetch --prune
+   git branch -r --list 'origin/m*'
+   ```
+
+   For each remote branch, check if the linked issue is still open. Categorize:
+   - **Stale**: issue is closed but branch still exists
+   - **Orphaned**: no issue found for this branch
+   - **Active**: issue is open
+
+2. **Scan local branches:**
+   ```bash
+   git branch --list 'm*'
+   ```
+
+   Check for local branches whose remote tracking branch is gone (`[gone]`).
+
+3. **Scan milestones:**
+   ```bash
+   gh milestone list --state open
+   ```
+
+   For each open milestone, check if all issues are closed. Flag milestones that should be closed.
+
+4. **Scan for stale issues** (optional — ask the user first since this is slower):
+   - Check open issues for references to files, functions, or classes that no longer exist in the codebase
+   - Tag stale issues with `needs-revision`
+
+5. **Present findings** to the user, grouped by category:
+
+   ```
+   Stale branches (issue closed, branch exists):
+     m5/34-improve-init-flow — #34 closed
+     m3/12-old-feature — #12 closed
+
+   Local-only branches (remote deleted):
+     m4-script-test [gone]
+
+   Milestones ready to close (all issues done):
+     Milestone 3 - GHP Improvements (3/3 closed)
+
+   Stale issues (references deleted code):
+     #9 — references `scripts/organize.sh` (deleted)
+   ```
+
+6. **Ask the user** via `AskUserQuestion` for each category what to do:
+
+   | Category | Options |
+   |---|---|
+   | Stale branches | Delete both / Delete remote only / Delete local only / Keep |
+   | Local-only branches | Delete / Keep |
+   | Milestones | Close / Keep open |
+   | Stale issues | Tag `needs-revision` / Close / Keep |
+
+7. **Execute** the user's choices and report what was done.

--- a/skills/ghp/commands/fresh/SKILL.md
+++ b/skills/ghp/commands/fresh/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: ghp:fresh
+description: Bootstrap a fresh agent (new conversation or subagent) onto a specific issue or let it pick from Todo. Loads full context — issue details, sub-issues, blocking, branch, plan — and starts working immediately. Use this when spinning up a new agent or starting a fresh conversation on a known issue.
+allowed-tools:
+  - Bash(gh issue *)
+  - Bash(gh issue-ext *)
+  - Bash(gh pm *)
+  - Bash(git *)
+---
+
+# /ghp:fresh — Bootstrap a Fresh Agent
+
+Loads all context needed to work on an issue and starts immediately. Designed for fresh conversations and subagents that have no prior context.
+
+## Flow
+
+### With issue number: `/ghp:fresh 42`
+
+1. **Fetch issue details:**
+   ```bash
+   gh issue view 42 --json title,body,state,labels,milestone
+   gh issue-ext show 42          # sub-issues, blocking, branches
+   gh issue-ext sub list 42      # sub-issues
+   gh issue-ext blocking list 42 # blockers
+   gh issue-ext branch list 42   # linked branch
+   ```
+
+2. **Check blockers.** If the issue has unresolved blockers, warn the user and ask whether to proceed or pick a different issue.
+
+3. **Move to In Progress:**
+   ```bash
+   gh pm move 42 --status in_progress
+   ```
+
+4. **Check out the linked branch.** Use the branch from `gh issue-ext branch list`. If no branch exists, create one following the naming convention:
+   - Under a milestone: `m{N}/{issue}-{slug}`
+   - Standalone: `{issue}-{slug}`
+
+5. **Read plan comments.** Check for plan comments on the issue:
+   ```bash
+   gh issue view 42 --json comments -q '.comments[].body'
+   ```
+   Look for comments starting with `## Plan` — these contain implementation plans from previous sessions.
+
+6. **Create TaskList.** If the issue has sub-issues, create tasks from them (sub-issues first, parent last). If no sub-issues, create a single task for the issue.
+
+7. **Start working.** Begin implementation based on the issue body and any plan comments.
+
+### Without issue number: `/ghp:fresh`
+
+1. **Fetch Todo issues:**
+   ```bash
+   gh pm list --status todo
+   ```
+
+2. **Check blocking status** for each Todo issue to find which are unblocked.
+
+3. **Present unblocked Todo issues** to the user via `AskUserQuestion` (up to 4 options, sorted by milestone first, then standalone).
+
+4. **Continue with the selected issue** — follow the "With issue number" flow above from step 1.


### PR DESCRIPTION
## Summary
- Add `/ghp:fresh` — bootstrap a fresh agent onto a specific issue or pick from Todo
- Add `/ghp:cleanup` — scan for stale branches, dead milestones, orphaned issues

closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)